### PR TITLE
PE-2879

### DIFF
--- a/app/uk/gov/hmrc/openidconnect/userinfo/connectors/DesConnector.scala
+++ b/app/uk/gov/hmrc/openidconnect/userinfo/connectors/DesConnector.scala
@@ -40,13 +40,13 @@ trait DesConnector {
     val newHc = hc.copy(authorization = Some(Authorization(s"Bearer $desBearerToken"))).withExtraHeaders("Environment" -> desEnvironment)
 
     authority.nino map { ninoString =>
-      val nino = Nino(ninoString) // validates and handles invalid nino value
-      val url = s"$serviceUrl/pay-as-you-earn/individuals/${withoutSuffix(nino.nino)}"
+      require(Nino.isValid(ninoString), s"$ninoString is not a valid nino.")
+      val url = s"$serviceUrl/pay-as-you-earn/individuals/${withoutSuffix(ninoString)}"
       Logger.debug(s"GET $url with environment=$desEnvironment")
 
       http.GET[DesUserInfo](url)(implicitly[HttpReads[DesUserInfo]], newHc) map (Some(_)) recover {
         case _: NotFoundException | _: BadRequestException =>
-          Logger.debug(s"User information for nino $nino is not available in DES")
+          Logger.debug(s"User information for nino $ninoString is not available in DES")
           None
       }
     } getOrElse {

--- a/app/uk/gov/hmrc/openidconnect/userinfo/data/UserInfoGenerator.scala
+++ b/app/uk/gov/hmrc/openidconnect/userinfo/data/UserInfoGenerator.scala
@@ -16,9 +16,10 @@
 
 package uk.gov.hmrc.openidconnect.userinfo.data
 
-import uk.gov.hmrc.openidconnect.userinfo.domain.{Address, Enrolment, EnrolmentIdentifier, UserInfo}
 import org.joda.time._
 import org.scalacheck.Gen
+import uk.gov.hmrc.openidconnect.userinfo.domain.{Address, Enrolment, EnrolmentIdentifier, GovernmentGatewayDetails, UserInfo}
+import uk.gov.hmrc.play.http.Token
 
 trait UserInfoGenerator {
   val firstNames = List(Some("Roland"), Some("Eddie"), Some("Susanna"), Some("Jake"), Some("Oy"), Some("Cuthbert"), Some("Alain"), Some("Jamie"), Some("Thomas"), Some("Susan"), Some("Randall"), None)
@@ -30,8 +31,10 @@ trait UserInfoGenerator {
       |NW1 9NT
       |Great Britain""".stripMargin, Some("NW1 9NT"), Some("Great Britain")))
   val enrolments = Seq(Enrolment("IR-SA", List(EnrolmentIdentifier("UTR", "174371121"))))
+  val government_gateway: GovernmentGatewayDetails = GovernmentGatewayDetails(Some("32131"),Some(Token("ggToken")),Some("User"),Some("affinityGroup"))
 
   private lazy val ninoPrefixes = "ABCEGHJKLMNPRSTWXYZ"
+
   private lazy val ninoSuffixes = "ABCD"
 
   private val nameGen = Gen.oneOf(firstNames)
@@ -43,6 +46,7 @@ trait UserInfoGenerator {
   private val prefixGen = Gen.oneOf(ninoPrefixes)
   private val suffixGen = Gen.oneOf(ninoSuffixes)
   private val numbersGen = Gen.choose(100000, 999999)
+  private val email = s"${nameGen}.${lastNameGen}@abc.uk"
 
   private def dateOfBirth = {
     for {
@@ -61,13 +65,14 @@ trait UserInfoGenerator {
     } yield s"$first$second$number$suffix"
   }
 
+
   val userInfo = for {
     name <- nameGen
     lastName <- lastNameGen
     middleName <- middleNameGen
     dob <- dateOfBirth
     nino <- formattedNino
-  } yield UserInfo(name, lastName, middleName, address, Some(dob), Some(nino), Some(enrolments))
+  } yield UserInfo(name, lastName, middleName, address, Some(email), Some(dob), Some(nino), Some(enrolments), Some(government_gateway))
 }
 
 object UserInfoGenerator extends UserInfoGenerator

--- a/app/uk/gov/hmrc/openidconnect/userinfo/domain/Authority.scala
+++ b/app/uk/gov/hmrc/openidconnect/userinfo/domain/Authority.scala
@@ -16,17 +16,10 @@
 
 package uk.gov.hmrc.openidconnect.userinfo.domain
 
-case class EnrolmentIdentifier(key: String, value: String)
-
-case class Enrolment(key: String,
-                     identifiers: Seq[EnrolmentIdentifier] = Seq(),
-                     state: String = "Activated") {
-
-  def isActivated = state.toLowerCase == "activated"
-}
-
-case object ActiveEnrolment {
-  def unapply(enrolment: Enrolment): Option[String] =
-    if (enrolment.isActivated) Some(enrolment.key)
-    else None
-}
+case class Authority(credentialStrength: Option[String] = None,
+                     confidenceLevel: Option[Int] = None,
+                     nino: Option[String] = None,
+                     userDetailsLink: Option[String] = None,
+                     enrolments: Option[String] = None,
+                     affinityGroup: Option[String] = None,
+                     credId: Option[String] = None)

--- a/app/uk/gov/hmrc/openidconnect/userinfo/domain/GovernmentGatewayDetails.scala
+++ b/app/uk/gov/hmrc/openidconnect/userinfo/domain/GovernmentGatewayDetails.scala
@@ -16,17 +16,11 @@
 
 package uk.gov.hmrc.openidconnect.userinfo.domain
 
-case class EnrolmentIdentifier(key: String, value: String)
+import uk.gov.hmrc.play.http.Token
 
-case class Enrolment(key: String,
-                     identifiers: Seq[EnrolmentIdentifier] = Seq(),
-                     state: String = "Activated") {
-
-  def isActivated = state.toLowerCase == "activated"
-}
-
-case object ActiveEnrolment {
-  def unapply(enrolment: Enrolment): Option[String] =
-    if (enrolment.isActivated) Some(enrolment.key)
-    else None
-}
+case class GovernmentGatewayDetails(
+                        user_id: Option[String],
+                        gateway_token: Option[Token],
+                        role: Option[String],
+                        affinityGroup: Option[String]
+                      )

--- a/app/uk/gov/hmrc/openidconnect/userinfo/domain/UserDetails.scala
+++ b/app/uk/gov/hmrc/openidconnect/userinfo/domain/UserDetails.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2017 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.openidconnect.userinfo.domain
+
+import org.joda.time.LocalDate
+
+case class UserDetails (
+                         authProviderId: Option[String] = None,
+                         authProviderType: Option[String] = None,
+                         name: Option[String] = None,
+                         lastName: Option[String] = None,
+                         dateOfBirth: Option[LocalDate] = None,
+                         postCode: Option[String] = None,
+                         email: Option[String] = None,
+                         affinityGroup: Option[String] = None,
+                         agentCode: Option[String] = None,
+                         agentFriendlyName: Option[String] = None,
+                         credentialRole: Option[String] = None,
+                         description: Option[String] = None,
+                         groupIdentifier: Option[String] = None
+                       )

--- a/app/uk/gov/hmrc/openidconnect/userinfo/domain/UserInfo.scala
+++ b/app/uk/gov/hmrc/openidconnect/userinfo/domain/UserInfo.scala
@@ -26,9 +26,11 @@ case class UserInfo(given_name: Option[String],
                     family_name: Option[String],
                     middle_name: Option[String],
                     address: Option[Address],
+                    email: Option[String],
                     birthdate: Option[LocalDate],
                     uk_gov_nino: Option[String],
-                    hmrc_enrolments: Option[Seq[Enrolment]])
+                    hmrc_enrolments: Option[Seq[Enrolment]],
+                    government_gateway: Option[GovernmentGatewayDetails])
 
 case class UserInformation(profile: Option[UserProfile],
                            address: Option[Address],

--- a/app/uk/gov/hmrc/openidconnect/userinfo/domain/package.scala
+++ b/app/uk/gov/hmrc/openidconnect/userinfo/domain/package.scala
@@ -17,25 +17,15 @@
 package uk.gov.hmrc.openidconnect.userinfo
 
 import org.joda.time.LocalDate
-import play.api.libs.json._
 import play.api.libs.functional.syntax._
+import play.api.libs.json._
+import uk.gov.hmrc.play.http.Token
 
 package object domain {
 
-  implicit val desUserName : Reads[DesUserName] = (
-  (JsPath \ "firstForenameOrInitial").readNullable[String] and
-  (JsPath \ "secondForenameOrInitial").readNullable[String] and
-  (JsPath \ "surname").readNullable[String]
-  )(DesUserName.apply _)
+  implicit val desUserName = Json.format[DesUserName]
 
-  implicit val desAddress : Reads[DesAddress] = (
-  (JsPath \ "line1").readNullable[String] and
-  (JsPath \ "line2").readNullable[String] and
-  (JsPath \ "line3").readNullable[String] and
-  (JsPath \ "line4").readNullable[String] and
-  (JsPath \ "postcode").readNullable[String] and
-  (JsPath \ "countryCode").readNullable[Int]
-  )(DesAddress.apply _)
+  implicit val desAddress = Json.format[DesAddress]
 
   implicit val desUserInfo : Reads[DesUserInfo] = (
   (JsPath \ "names" \ "1").read[DesUserName] and
@@ -43,26 +33,17 @@ package object domain {
   (JsPath \ "addresses" \ "1").read[DesAddress]
   )(DesUserInfo.apply _)
 
-  implicit val idformat = Json.format[EnrolmentIdentifier]
-  implicit val format = Format(
-    ((__ \ "key").read[String] and
-      (__ \ "identifiers").read[Seq[EnrolmentIdentifier]] and
-      (__ \ "state").readNullable[String]) {
-      (key, ids, optState) =>
-        Enrolment(
-          key,
-          ids,
-          optState.getOrElse("Activated")
-        )
-    },
-    Writes[Enrolment] { enrolment =>
-      Json.writes[Enrolment].writes(enrolment).as[JsObject]
-    }
-  )
+  implicit val enrolmentIdentifier = Json.format[EnrolmentIdentifier]
+  implicit val enrloment = Json.format[Enrolment]
+
+  implicit val token = Json.format[Token]
+  implicit val userDetails = Json.format[UserDetails]
+  implicit val governmentGatewayDetails = Json.format[GovernmentGatewayDetails]
 
   implicit val dateReads = Reads.jodaDateReads("yyyy-MM-dd")
   implicit val dateWrites = Writes.jodaDateWrites("yyyy-MM-dd")
   implicit val addressFmt = Json.format[Address]
+  implicit val authorityFmt = Json.format[Authority]
   implicit val userInfoFmt = Json.format[UserInfo]
   implicit val apiAccessFmt = Json.format[APIAccess]
 }

--- a/app/uk/gov/hmrc/openidconnect/userinfo/services/AuthService.scala
+++ b/app/uk/gov/hmrc/openidconnect/userinfo/services/AuthService.scala
@@ -17,16 +17,18 @@
 package uk.gov.hmrc.openidconnect.userinfo.services
 
 import uk.gov.hmrc.openidconnect.userinfo.connectors.AuthConnector
+import uk.gov.hmrc.play.auth.microservice.connectors.ConfidenceLevel
 import uk.gov.hmrc.play.auth.microservice.connectors.ConfidenceLevel.L200
 import uk.gov.hmrc.play.http.HeaderCarrier
+
 import scala.concurrent.ExecutionContext.Implicits.global
 
 trait AuthService {
   val authConnector: AuthConnector
 
   def isAuthorised()(implicit hc: HeaderCarrier) = {
-    authConnector.confidenceLevel().map {
-      case Some(cf) => cf >= L200.level
+    authConnector.fetchAuthority().map {
+      case Some(auth) => auth.confidenceLevel.getOrElse(ConfidenceLevel.L0.level) >= L200.level
       case None => false
     }
   }

--- a/app/uk/gov/hmrc/openidconnect/userinfo/services/UserInfoService.scala
+++ b/app/uk/gov/hmrc/openidconnect/userinfo/services/UserInfoService.scala
@@ -47,12 +47,12 @@ trait LiveUserInfoService extends UserInfoService {
 
     scopes flatMap { scopes =>
       def getMaybeForScopes[T](maybeScopes: Set[String], allScopes: Set[String], f: => Future[Option[T]]): Future[Option[T]] = {
-        if ((maybeScopes -- allScopes).size != maybeScopes.size) f
+        if ((maybeScopes intersect allScopes).size > 0) f
         else Future.successful(None)
       }
 
       def getMaybeByParamForScopes[I, O](maybeScopes: Set[String], allScopes: Set[String], param: I, f: I => Future[Option[O]]): Future[Option[O]] = {
-        if ((maybeScopes -- allScopes).size != maybeScopes.size) f(param)
+        if ((maybeScopes intersect allScopes).size > 0) f(param)
         else Future.successful(None)
       }
 

--- a/app/uk/gov/hmrc/openidconnect/userinfo/services/UserInfoService.scala
+++ b/app/uk/gov/hmrc/openidconnect/userinfo/services/UserInfoService.scala
@@ -17,16 +17,14 @@
 package uk.gov.hmrc.openidconnect.userinfo.services
 
 import play.api.Logger
-import uk.gov.hmrc.domain.Nino
-import uk.gov.hmrc.openidconnect.userinfo.connectors.{AuthConnector, DesConnector, ThirdPartyDelegatedAuthorityConnector}
+import uk.gov.hmrc.openidconnect.userinfo.connectors._
 import uk.gov.hmrc.openidconnect.userinfo.data.UserInfoGenerator
 import uk.gov.hmrc.openidconnect.userinfo.domain._
 import uk.gov.hmrc.play.http.logging.Authorization
 import uk.gov.hmrc.play.http.{HeaderCarrier, UnauthorizedException}
 
 import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.{Future, Promise}
-import scala.util.{Failure, Success}
+import scala.concurrent.Future
 
 trait UserInfoService {
   def fetchUserInfo()(implicit hc: HeaderCarrier): Future[Option[UserInfo]]
@@ -37,7 +35,7 @@ trait LiveUserInfoService extends UserInfoService {
   val desConnector: DesConnector
   val userInfoTransformer: UserInfoTransformer
   val thirdPartyDelegatedAuthorityConnector: ThirdPartyDelegatedAuthorityConnector
-
+  val userDetailsConnector: UserDetailsConnector
 
   override def fetchUserInfo()(implicit hc: HeaderCarrier): Future[Option[UserInfo]] = {
     def bearerToken(authorization: Authorization) = augmentString(authorization.value).stripPrefix("Bearer ")
@@ -47,39 +45,41 @@ trait LiveUserInfoService extends UserInfoService {
       case None => Future.failed(new UnauthorizedException("Bearer token is required"))
     }
 
-    val promiseNino = Promise[Option[Nino]]()
-    val maybeNino = promiseNino.future
-
     scopes flatMap { scopes =>
-      val scopesForNino = Set("profile", "address", "openid:gov-uk-identifiers")
-      if ((scopesForNino -- scopes).size != scopesForNino.size) {
-        authConnector.fetchNino() onComplete {
-          case Success(nino) => promiseNino success nino
-          case Failure(exception) => throw exception
-        }
-      } else promiseNino success None
+      def getMaybeForScopes[T](maybeScopes: Set[String], allScopes: Set[String], f: => Future[Option[T]]): Future[Option[T]] = {
+        if ((maybeScopes -- allScopes).size != maybeScopes.size) f
+        else Future.successful(None)
+      }
 
-      val promiseDesUserInfo = Promise[Option[DesUserInfo]]
-      val maybeDesUserInfo = promiseDesUserInfo.future
+      def getMaybeByParamForScopes[I, O](maybeScopes: Set[String], allScopes: Set[String], param: I, f: I => Future[Option[O]]): Future[Option[O]] = {
+        if ((maybeScopes -- allScopes).size != maybeScopes.size) f(param)
+        else Future.successful(None)
+      }
 
-      val scopesDes = Set("profile", "address")
-      if ((scopesDes -- scopes).size != scopesDes.size) {
-        maybeNino onComplete {
-          case Success(hopefulyNino) => desConnector.fetchUserInfo(hopefulyNino) onComplete {
-            case Success(desUserInfo) => promiseDesUserInfo success desUserInfo
-            case Failure(exception) => throw exception
-          }
-          case Failure(exception) => throw exception
-        }
-      } else promiseDesUserInfo success None
+      val scopesForAuthority = Set("openid:government_gateway", "email", "profile", "address", "openid:gov-uk-identifiers", "openid:hmrc_enrolments")
+      val maybeAuthority = getMaybeForScopes(scopesForAuthority, scopes, authConnector.fetchAuthority)
 
-      def maybeEnrolments = if (scopes.contains("openid:hmrc_enrolments")) authConnector.fetchEnrolments() else Future.successful(None)
+      val scopesForDes = Set("profile", "address")
+      val maybeDesUserInfo = maybeAuthority flatMap { authority =>
+        getMaybeByParamForScopes[Authority, DesUserInfo](scopesForDes, scopes, authority.getOrElse(Authority()), desConnector.fetchUserInfo)
+      }
+
+      val scopesForUserDetails = Set("openid:government_gateway", "email")
+      val maybeUserDetails = maybeAuthority flatMap { authority =>
+        getMaybeByParamForScopes[Authority, UserDetails](scopesForUserDetails, scopes, authority.getOrElse(Authority()), userDetailsConnector.fetchUserDetails)
+      }
+
+      def maybeEnrolments = maybeAuthority flatMap { authority =>
+        getMaybeByParamForScopes[Authority, Seq[Enrolment]](Set("openid:hmrc_enrolments"), scopes,
+          authority.getOrElse(Authority()), authConnector.fetchEnrolments)
+      }
 
       val future: Future[UserInfo] = for {
-        nino <- maybeNino
         enrolments <- maybeEnrolments
         desUserInfo <- maybeDesUserInfo
-      } yield userInfoTransformer.transform(scopes, desUserInfo, nino, enrolments)
+        authority <- maybeAuthority
+        userDetails <- maybeUserDetails
+      } yield userInfoTransformer.transform(scopes, desUserInfo, enrolments, authority, userDetails, hc.token)
 
       future map (Some((_: UserInfo))) recover {
         case e: Throwable => {
@@ -104,6 +104,7 @@ object LiveUserInfoService extends LiveUserInfoService {
   override val authConnector = AuthConnector
   override val userInfoTransformer = UserInfoTransformer
   override val thirdPartyDelegatedAuthorityConnector = ThirdPartyDelegatedAuthorityConnector
+  override val userDetailsConnector = UserDetailsConnector
 }
 
 object SandboxUserInfoService extends SandboxUserInfoService {

--- a/app/uk/gov/hmrc/openidconnect/userinfo/views/definition.scala.txt
+++ b/app/uk/gov/hmrc/openidconnect/userinfo/views/definition.scala.txt
@@ -33,6 +33,18 @@
       "name":"Access your enrolments",
       "description":"Access your enrolments",
       "confidenceLevel": 200
+    },
+    {
+      "key":"openid:government_gateway",
+      "name":"Shows subset of your government gateway details",
+      "description":"Shows subset of yours government gateway details",
+      "confidenceLevel": 200
+    },
+    {
+      "key":"email",
+      "name":"Shows your email address",
+      "description":"Shows your email address",
+      "confidenceLevel": 200
     }
   ],
   "api":{

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -180,6 +180,11 @@ Test {
                 host=localhost
                 port=22223
             }
+
+            user-details {
+                host=localhost
+                port=22224
+            }
         }
     }
 }
@@ -241,6 +246,11 @@ Dev {
                 host=localhost
                 port=9606
             }
+
+            user-details {
+                host=localhost
+                port=9978
+            }
         }
     }
 }
@@ -299,6 +309,11 @@ Prod {
 
             third-party-delegated-authority {
                 host=third-party-delegated-authority.service
+                port=80
+            }
+
+            user-details {
+                host=user-details.service
                 port=80
             }
         }

--- a/conf/live.routes
+++ b/conf/live.routes
@@ -1,2 +1,2 @@
-GET /             uk.gov.hmrc.openidconnect.userinfo.controllers.LiveUserInfoController.userInfo
+GET /            uk.gov.hmrc.openidconnect.userinfo.controllers.LiveUserInfoController.userInfo
 POST /            uk.gov.hmrc.openidconnect.userinfo.controllers.LiveUserInfoController.userInfo

--- a/project/MicroserviceBuild.scala
+++ b/project/MicroserviceBuild.scala
@@ -21,11 +21,11 @@ private object AppDependencies {
 
   val compile = Seq(
     ws,
-    "uk.gov.hmrc" %% "microservice-bootstrap" % "5.14.0",
-    "uk.gov.hmrc" %% "play-authorisation" % "4.3.0",
-    "uk.gov.hmrc" %% "play-config" % "4.3.0",
+    "uk.gov.hmrc" %% "microservice-bootstrap" % "5.8.0",
+    "uk.gov.hmrc" %% "play-authorisation" % "4.2.0",
+    "uk.gov.hmrc" %% "play-config" % "3.0.0",
     "uk.gov.hmrc" %% "logback-json-logger" % "3.1.0",
-    "uk.gov.hmrc" %% "play-health" % "2.1.0",
+    "uk.gov.hmrc" %% "play-health" % "2.0.0",
     "org.scalacheck" %% "scalacheck" % "1.12.5",
     "uk.gov.hmrc" %% "play-hmrc-api" % "1.2.0",
     "uk.gov.hmrc" %% "domain" % "4.0.0"

--- a/project/MicroserviceBuild.scala
+++ b/project/MicroserviceBuild.scala
@@ -21,11 +21,11 @@ private object AppDependencies {
 
   val compile = Seq(
     ws,
-    "uk.gov.hmrc" %% "microservice-bootstrap" % "5.8.0",
-    "uk.gov.hmrc" %% "play-authorisation" % "4.2.0",
-    "uk.gov.hmrc" %% "play-config" % "3.0.0",
+    "uk.gov.hmrc" %% "microservice-bootstrap" % "5.14.0",
+    "uk.gov.hmrc" %% "play-authorisation" % "4.3.0",
+    "uk.gov.hmrc" %% "play-config" % "4.3.0",
     "uk.gov.hmrc" %% "logback-json-logger" % "3.1.0",
-    "uk.gov.hmrc" %% "play-health" % "2.0.0",
+    "uk.gov.hmrc" %% "play-health" % "2.1.0",
     "org.scalacheck" %% "scalacheck" % "1.12.5",
     "uk.gov.hmrc" %% "play-hmrc-api" % "1.2.0",
     "uk.gov.hmrc" %% "domain" % "4.0.0"

--- a/public/api/conf/1.0/examples/get-user-info-example-1.json
+++ b/public/api/conf/1.0/examples/get-user-info-example-1.json
@@ -7,6 +7,7 @@
     "postal_code" : "NW1 9NT",
     "country" : "Great Britain"
   },
+  "email" : "John.Smith@abc.uk",
   "birthdate" : "1950-01-01",
   "uk_gov_nino" : "AA000003D",
   "hmrc_enrolments": [
@@ -20,5 +21,12 @@
       ],
       "state": "activated"
     }
-  ]
+  ],
+  "government_gateway":
+  {
+    "user_id": "019283",
+    "gateway_token": "gg7063",
+    "roles": ["User"],
+    "affinity_group": "Individual"
+  }
 }

--- a/public/api/conf/1.0/schemas/userinfo.json
+++ b/public/api/conf/1.0/schemas/userinfo.json
@@ -18,6 +18,11 @@
       "description": "End-user's last name.",
       "example": "Delgado"
     },
+    "email" : {
+      "type" : "string",
+      "description" : "User email",
+      "example" : "Cling.Eastwood@wildwest.com"
+    },
     "birthdate": {
       "type": "string",
       "description": "End-User's birthday, represented as an ISO 8601:2004 [ISO8601‑2004] YYYY-MM-DD format.",
@@ -81,6 +86,32 @@
         }
       },
       "required": ["service", "identifiers", "state"]
+    },
+    "government_gateway": {
+      "type": "object",
+      "description": "Legacy properties based on government gateway input.",
+      "properties" : {
+        "user_id" : {
+          "type": "string",
+          "description": "Cred id",
+          "example" : "1012345"
+        },
+        "gateway_token" : {
+          "type" : "string",
+          "description": "Government gateway token",
+          "example": "c29tZSBtYWdpYyBobXJjIGdnIHRva2Vu"
+        },
+        "roles" : {
+          "type" : "array",
+          "description" : "List of user's roles",
+          "example" : ["User"]
+        },
+        "affinity_group" : {
+          "type" : "string",
+          "description" : "User affinity group",
+          "example" : "Individual"
+        }
+      }
     }
   }
 }

--- a/test/it/BaseFeatureSpec.scala
+++ b/test/it/BaseFeatureSpec.scala
@@ -19,9 +19,9 @@ package it
 import com.github.tomakehurst.wiremock.WireMockServer
 import com.github.tomakehurst.wiremock.client.WireMock
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration
-import it.stubs.{AuthStub, DesStub, ThirdPartyDelegatedAuthorityStub}
+import it.stubs.{AuthStub, DesStub, ThirdPartyDelegatedAuthorityStub, UserDetailsStub}
 import org.scalatest._
-import org.scalatestplus.play.{OneServerPerSuite, OneServerPerTest}
+import org.scalatestplus.play.OneServerPerTest
 
 import scala.concurrent.duration._
 
@@ -35,11 +35,13 @@ with BeforeAndAfterEach with BeforeAndAfterAll with OneServerPerTest {
   val authStub = AuthStub
   val desStub = DesStub
   val thirdPartyDelegatedAuthorityStub = ThirdPartyDelegatedAuthorityStub
+  val userDetailsStub = UserDetailsStub
 
-  val mocks = Seq(authStub, desStub, thirdPartyDelegatedAuthorityStub)
+  val mocks = Seq(authStub, desStub, thirdPartyDelegatedAuthorityStub, userDetailsStub)
 
   override protected def beforeEach(): Unit = {
-    mocks.foreach(m => if (!m.stub.server.isRunning) m.stub.server.start())
+    mocks.foreach(m => if (!m.stub.server.isRunning) m.stub.server.start()
+    )
   }
 
   override protected def afterEach(): Unit = {

--- a/test/it/SchemaSpec.scala
+++ b/test/it/SchemaSpec.scala
@@ -1,24 +1,42 @@
+/*
+ * Copyright 2017 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package it
 
 import java.nio.file.Paths
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.github.fge.jsonschema.main.JsonSchemaFactory
+import org.scalatest.FlatSpec
 
 
-class SchemaSpec extends BaseFeatureSpec {
-  feature("check schema and example json") {
-    val validator = JsonSchemaFactory.byDefault().getValidator
-    val root = System.getProperty("user.dir")
-    val public10 = Paths.get(root, "public", "api", "conf", "1.0").toString
-    val mapper = new ObjectMapper
+class SchemaSpec extends FlatSpec {
+  val validator = JsonSchemaFactory.byDefault().getValidator
+  val root = System.getProperty("user.dir")
+  val public10 = Paths.get(root, "public", "api", "conf", "1.0").toString
+  val mapper = new ObjectMapper
 
-    scenario("validate json") {
-      val schema = mapper.readTree(Paths.get(public10, "schemas", "userinfo.json").toFile)
-      val exampleJSON = mapper.readTree(Paths.get(public10, "examples", "get-user-info-example-1.json").toFile)
-      val report = validator.validate(schema, exampleJSON)
+  val schema = mapper.readTree(Paths.get(public10, "schemas", "userinfo.json").toFile)
+  val exampleJSON = mapper.readTree(Paths.get(public10, "examples", "get-user-info-example-1.json").toFile)
 
-      report.isSuccess shouldBe true
-    }
+  "A schema and example JSON" should "be valid" in {
+    val syntaxValidator = JsonSchemaFactory.byDefault().getSyntaxValidator
+    assert(syntaxValidator.schemaIsValid(schema), "Schema is NOT valid.")
+
+    val report = validator.validate(schema, exampleJSON)
+    assert(report.isSuccess)
   }
 }

--- a/test/it/stubs/AuthStub.scala
+++ b/test/it/stubs/AuthStub.scala
@@ -28,11 +28,15 @@ object AuthStub extends Stub {
     stub.mock.register(get(urlPathEqualTo(s"/auth/authority"))
       .willReturn(aResponse().withBody(
         s"""
-          |{
-          |   "confidenceLevel": ${confidenceLevel.level},
-          |   "nino": "${nino.nino}",
-          |   "enrolments": "/auth/oid/2/enrolments"
-          |}
+           |{
+           |   "credentialStrength:": "strong",
+           |   "confidenceLevel": ${confidenceLevel.level},
+           |   "userDetailsLink": "http://localhost:22224/uri/to/userDetails",
+           |   "nino": "${nino.nino}",
+           |   "enrolments": "/auth/oid/2/enrolments",
+           |   "affinityGroup": "Individual",
+           |   "credId": "1304372065861347"
+           |}
         """.stripMargin
       )))
   }

--- a/test/it/stubs/UserDetailsStub.scala
+++ b/test/it/stubs/UserDetailsStub.scala
@@ -14,19 +14,25 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.openidconnect.userinfo.domain
+package it.stubs
 
-case class EnrolmentIdentifier(key: String, value: String)
+import com.github.tomakehurst.wiremock.client.WireMock._
+import it.{MockHost, Stub}
 
-case class Enrolment(key: String,
-                     identifiers: Seq[EnrolmentIdentifier] = Seq(),
-                     state: String = "Activated") {
+object UserDetailsStub extends Stub {
+  override val stub: MockHost = new MockHost(22224)
 
-  def isActivated = state.toLowerCase == "activated"
-}
+  def willReturnUserDetailsWith(email: String) = {
+    stub.mock.register(get(urlPathEqualTo(s"/uri/to/userDetails"))
+      .willReturn(aResponse().withBody(
+        s"""
+           |{
+           |   "affinityGroup": "Individual",
+           |   "credentialRole": "Admin",
+           |   "email": "$email"
+           |}
+        """.stripMargin
+      )))
+  }
 
-case object ActiveEnrolment {
-  def unapply(enrolment: Enrolment): Option[String] =
-    if (enrolment.isActivated) Some(enrolment.key)
-    else None
 }

--- a/test/unit/uk/gov/hmrc/openidconnect/userinfo/connectors/AuthConnectorSpec.scala
+++ b/test/unit/uk/gov/hmrc/openidconnect/userinfo/connectors/AuthConnectorSpec.scala
@@ -28,40 +28,6 @@ import unit.uk.gov.hmrc.openidconnect.userinfo.WireMockSugar
 
 class AuthConnectorSpec extends WireMockSugar {
 
-//  "confidenceLevel" should {
-//    "be the authority's confidence level" in new TestAuthConnector(wiremockBaseUrl) {
-//      given().get(urlPathEqualTo("/auth/authority")).returns(authorityJson(L200))
-//      confidenceLevel().futureValue shouldBe Some(200)
-//    }
-//
-//    "return None when authority's confidence level is not in the response" in new TestAuthConnector(wiremockBaseUrl) {
-//      given().get(urlPathEqualTo("/auth/authority")).returns("""{"credentialStrength":"weak"}""")
-//      confidenceLevel().futureValue shouldBe None
-//    }
-//
-//    "return false when auth request fails" in new TestAuthConnector(wiremockBaseUrl) {
-//      given().get(urlPathEqualTo("/auth/authority")).returns(500)
-//      confidenceLevel().futureValue shouldBe None
-//    }
-//  }
-
-//  "fetchNino" should {
-//    "return the authority's nino" in new TestAuthConnector(wiremockBaseUrl) {
-//      given().get(urlPathEqualTo("/auth/authority")).returns("""{"nino":"NB966669A"}""")
-//      fetchNino().futureValue shouldBe Some(Nino("NB966669A"))
-//    }
-//
-//    "return None when authority's NINO is not in the response" in new TestAuthConnector(wiremockBaseUrl) {
-//      given().get(urlPathEqualTo("/auth/authority")).returns("""{"credentialStrength":"weak"}""")
-//      fetchNino().futureValue shouldBe None
-//    }
-//
-//    "return None when auth request fails" in new TestAuthConnector(wiremockBaseUrl) {
-//      given().get(urlPathEqualTo("/auth/authority")).returns(500)
-//      fetchNino().futureValue shouldBe None
-//    }
-//  }
-
   "fetchEnrloments" should {
     val authority = Authority(Some("weak"), Some(200), Some("AA111111A"), Some("/uri/to/userDetails"),
       Some("/uri/to/enrolments"), Some("Individual"), Some("1304372065861347"))

--- a/test/unit/uk/gov/hmrc/openidconnect/userinfo/connectors/UserDetailsConnectorSpec.scala
+++ b/test/unit/uk/gov/hmrc/openidconnect/userinfo/connectors/UserDetailsConnectorSpec.scala
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2017 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package unit.uk.gov.hmrc.openidconnect.userinfo.connectors
+
+import com.github.tomakehurst.wiremock.WireMockServer
+import com.github.tomakehurst.wiremock.client.WireMock._
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.concurrent.ScalaFutures
+import uk.gov.hmrc.openidconnect.userinfo.config.WSHttp
+import uk.gov.hmrc.openidconnect.userinfo.connectors.UserDetailsConnector
+import uk.gov.hmrc.openidconnect.userinfo.domain.{Authority, UserDetails}
+import uk.gov.hmrc.play.http.{HeaderCarrier, HttpGet}
+import uk.gov.hmrc.play.test.{UnitSpec, WithFakeApplication}
+import unit.uk.gov.hmrc.openidconnect.userinfo.WiremockDSL
+
+class UserDetailsConnectorSpec extends UnitSpec with BeforeAndAfterAll with WithFakeApplication with WiremockDSL with ScalaFutures {
+  val stubPort = sys.env.getOrElse("WIREMOCK", "11111").toInt
+  val stubHost = "localhost"
+  val wireMockUrl = s"http://$stubHost:$stubPort"
+  val wireMockServerUserDetails = new WireMockServer(wireMockConfig().port(stubPort))
+
+  trait Setup {
+    implicit val hc: HeaderCarrier = HeaderCarrier()
+
+    val connector = new UserDetailsConnector {
+      override val http: HttpGet = WSHttp
+    }
+
+    def userDetailsJson() = {
+      s"""
+         |{
+         |   "affinityGroup": "Individual",
+         |   "credentialRole": "Admin",
+         |   "email": "fst.snd@name.com"
+         |}
+        """.stripMargin
+    }
+  }
+
+  override def beforeAll() {
+    super.beforeAll()
+    wireMockServerUserDetails.start()
+    configureFor(stubHost, stubPort)
+  }
+
+  override def afterAll() {
+    super.afterAll()
+    wireMockServerUserDetails.resetMappings()
+    wireMockServerUserDetails.stop()
+  }
+
+  "fetchUserDetails" should {
+    val userDetailsPath = "/uri/to/userDetails"
+    val userDetailsUri = s"$wireMockUrl$userDetailsPath"
+    val authority: Authority = Authority(Some("weak"), Some(200), Some("AA111111A"), Some(userDetailsUri),
+      Some("/uri/to/enrolments"), Some("Individual"), Some("1304372065861347"))
+
+    "return user details" in new Setup() {
+      given().get(urlPathEqualTo(s"$userDetailsPath")).returns(userDetailsJson())
+      connector.fetchUserDetails(authority).futureValue shouldBe Some(UserDetails(affinityGroup = Some("Individual"), credentialRole = Some("Admin"), email = Some("fst.snd@name.com")))
+    }
+
+    "return user details with affinity group only" in new Setup() {
+      given().get(urlPathEqualTo(s"$userDetailsPath")).returns("""{"affinityGroup": "Individual"}""")
+      connector.fetchUserDetails(authority).futureValue shouldBe Some(UserDetails(affinityGroup = Some("Individual")))
+    }
+
+    "return user details with credential role only" in new Setup() {
+      given().get(urlPathEqualTo(s"$userDetailsPath")).returns("""{"credentialRole": "Admin"}""")
+      connector.fetchUserDetails(authority).futureValue shouldBe Some(UserDetails(credentialRole = Some("Admin")))
+    }
+
+    "return user empty UserDetails if there are no user details" in new Setup() {
+      given().get(urlPathEqualTo(s"$userDetailsPath")).returns("{}")
+      connector.fetchUserDetails(authority).futureValue shouldBe Some(UserDetails())
+    }
+  }
+}

--- a/test/unit/uk/gov/hmrc/openidconnect/userinfo/controllers/UserInfoControllerSpec.scala
+++ b/test/unit/uk/gov/hmrc/openidconnect/userinfo/controllers/UserInfoControllerSpec.scala
@@ -25,10 +25,10 @@ import org.scalatest.mock.MockitoSugar
 import play.api.libs.json.Json
 import play.api.test.FakeRequest
 import uk.gov.hmrc.openidconnect.userinfo.controllers.{LiveUserInfoController, SandboxUserInfoController}
-import uk.gov.hmrc.openidconnect.userinfo.domain.{Address, Enrolment, EnrolmentIdentifier, UserInfo}
+import uk.gov.hmrc.openidconnect.userinfo.domain.{Address, Enrolment, EnrolmentIdentifier, GovernmentGatewayDetails, UserInfo}
 import uk.gov.hmrc.openidconnect.userinfo.services.{LiveUserInfoService, SandboxUserInfoService}
 import uk.gov.hmrc.play.filters.MicroserviceFilterSupport
-import uk.gov.hmrc.play.http.HeaderCarrier
+import uk.gov.hmrc.play.http.{HeaderCarrier, Token}
 import uk.gov.hmrc.play.test.{UnitSpec, WithFakeApplication}
 
 class UserInfoControllerSpec extends UnitSpec with MockitoSugar with ScalaFutures with WithFakeApplication {
@@ -38,10 +38,11 @@ class UserInfoControllerSpec extends UnitSpec with MockitoSugar with ScalaFuture
     Some("Smith"),
     Some("Hannibal"),
     Some(Address("221B\\BAKER STREET\\nLONDON\\NW1 9NT\\nUnited Kingdom", Some("NW1 9NT"), Some("United Kingdom"))),
+    Some("John.Smith@a.b.c.com"),
     Some(LocalDate.parse("1982-11-15")),
     Some("AR778351B"),
-    Some(Seq(Enrolment("IR-SA", List(EnrolmentIdentifier("UTR", "174371121")))))
-  )
+    Some(Seq(Enrolment("IR-SA", List(EnrolmentIdentifier("UTR", "174371121"))))),
+    Some(GovernmentGatewayDetails(Some("32131"),Some(Token("ggToken")),Some("User"),Some("affinityGroup"))))
 
   trait Setup extends MicroserviceFilterSupport {
     val mockLiveUserInfoService = mock[LiveUserInfoService]

--- a/test/unit/uk/gov/hmrc/openidconnect/userinfo/services/UserInfoServiceSpec.scala
+++ b/test/unit/uk/gov/hmrc/openidconnect/userinfo/services/UserInfoServiceSpec.scala
@@ -22,13 +22,16 @@ import org.mockito.Mockito.{never, verify}
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.mock.MockitoSugar
 import uk.gov.hmrc.domain.Nino
-import uk.gov.hmrc.openidconnect.userinfo.connectors.{AuthConnector, DesConnector, ThirdPartyDelegatedAuthorityConnector}
+import uk.gov.hmrc.openidconnect.userinfo.connectors.{AuthConnector, DesConnector, ThirdPartyDelegatedAuthorityConnector, UserDetailsConnector}
 import uk.gov.hmrc.openidconnect.userinfo.data.UserInfoGenerator
 import uk.gov.hmrc.openidconnect.userinfo.domain._
 import uk.gov.hmrc.openidconnect.userinfo.services.{LiveUserInfoService, SandboxUserInfoService, UserInfoTransformer}
-import uk.gov.hmrc.play.http.HeaderCarrier
 import uk.gov.hmrc.play.http.logging.Authorization
+import uk.gov.hmrc.play.http.{HeaderCarrier, Token}
 import uk.gov.hmrc.play.test.UnitSpec
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
 
 class UserInfoServiceSpec extends UnitSpec with MockitoSugar with ScalaFutures {
 
@@ -36,7 +39,17 @@ class UserInfoServiceSpec extends UnitSpec with MockitoSugar with ScalaFutures {
   val authBearerToken = "AUTH_BEARER_TOKEN"
   val desUserInfo = DesUserInfo(DesUserName(Some("John"), None, Some("Smith")), None, DesAddress(Some("1 Station Road"), Some("Town Centre"), None, None, None, None))
   val enrolments = Seq(Enrolment("IR-SA", List(EnrolmentIdentifier("UTR", "174371121"))))
-  val userInfo = UserInfo(Some("John"), Some("Smith"), None, Some(Address("1 Station Road\nTown Centre", None, None)),None, Some(nino).map(_.nino), Some(enrolments))
+  val authority: Authority = Authority(Some("weak"),Some(200),Some("AB123456A"),Some("/uri/to/userDetails"),
+    Some("/uri/to/enrolments"),Some("Individual"),Some("1304372065861347"))
+
+  val userDetails: UserDetails = UserDetails(None, None, None, None, None, None, None, Some("affinityGroup"), None, None,
+    Some("User"), None, None)
+
+  val governmentGateway: GovernmentGatewayDetails =  GovernmentGatewayDetails(Some("32131"),Some(Token("ggToken")),Some("User"),Some("affinityGroup"))
+
+  val ggToken = Token("ggToken")
+
+  val userInfo = UserInfo(Some("John"), Some("Smith"), None, Some(Address("1 Station Road\nTown Centre", None, None)),None, None, Some(nino).map(_.nino), Some(enrolments), Some(governmentGateway))
 
   trait Setup {
     implicit val headers = HeaderCarrier().copy(authorization = Some(Authorization(s"Bearer $authBearerToken")))
@@ -50,6 +63,7 @@ class UserInfoServiceSpec extends UnitSpec with MockitoSugar with ScalaFutures {
       override val desConnector: DesConnector = mock[DesConnector]
       override val userInfoTransformer = mock[UserInfoTransformer]
       override val thirdPartyDelegatedAuthorityConnector = mock[ThirdPartyDelegatedAuthorityConnector]
+      override val userDetailsConnector = mock[UserDetailsConnector]
     }
   }
 
@@ -57,24 +71,26 @@ class UserInfoServiceSpec extends UnitSpec with MockitoSugar with ScalaFutures {
 
     "requests all available data" in new Setup {
 
-      val scopes = Set("address", "profile", "openid:gov-uk-identifiers", "openid:hmrc_enrolments")
+      val scopes = Set("openid", "address", "profile", "openid:gov-uk-identifiers", "openid:hmrc_enrolments", "email", "openid:government_gateway")
       given(liveInfoService.thirdPartyDelegatedAuthorityConnector.fetchScopes(authBearerToken)(headers)).willReturn(scopes)
-      given(liveInfoService.authConnector.fetchNino()(headers)).willReturn(Some(nino))
-      given(liveInfoService.authConnector.fetchEnrolments()(headers)).willReturn(Some(enrolments))
-      given(liveInfoService.desConnector.fetchUserInfo(Some(nino))(headers)).willReturn(Some(desUserInfo))
-      given(liveInfoService.userInfoTransformer.transform(scopes, Some(desUserInfo), Some(nino), Some(enrolments))).willReturn(any[UserInfo], any[UserInfo])
+      given(liveInfoService.authConnector.fetchAuthority()(headers)).willReturn(Some(authority))
+      given(liveInfoService.authConnector.fetchEnrolments(authority)(headers)).willReturn(Some(enrolments))
+      given(liveInfoService.userDetailsConnector.fetchUserDetails(authority)(headers)).willReturn(Some(userDetails))
+      given(liveInfoService.desConnector.fetchUserInfo(authority)(headers)).willReturn(Some(desUserInfo))
+      given(liveInfoService.userInfoTransformer.transform(scopes, Some(desUserInfo), Some(enrolments), Some(authority), None, None)).willReturn(any[UserInfo], any[UserInfo])
 
       await(liveInfoService.fetchUserInfo())
 
-      verify(liveInfoService.desConnector).fetchUserInfo(Some(nino))
-      verify(liveInfoService.authConnector).fetchNino()
-      verify(liveInfoService.authConnector).fetchEnrolments()
+      verify(liveInfoService.desConnector).fetchUserInfo(authority)
+      verify(liveInfoService.authConnector).fetchEnrolments(authority)
+      verify(liveInfoService.authConnector).fetchAuthority()
+      verify(liveInfoService.userDetailsConnector).fetchUserDetails(any[Authority])(any[HeaderCarrier])
     }
 
     "return None when the NINO is not in the authority" in new Setup {
       val scopes = Set("address", "profile", "openid:gov-uk-identifiers", "openid:hmrc_enrolments")
       given(liveInfoService.thirdPartyDelegatedAuthorityConnector.fetchScopes(authBearerToken)(headers)).willReturn(scopes)
-      given(liveInfoService.authConnector.fetchNino()(headers)).willReturn(None)
+      given(liveInfoService.authConnector.fetchAuthority()(headers)).willReturn(Future(Option(authority.copy(nino = None))))
 
       val result = await(liveInfoService.fetchUserInfo())
 
@@ -86,15 +102,13 @@ class UserInfoServiceSpec extends UnitSpec with MockitoSugar with ScalaFutures {
       val scopes = Set("openid:gov-uk-identifiers", "openid:hmrc_enrolments")
       given(liveInfoService.thirdPartyDelegatedAuthorityConnector.fetchScopes(authBearerToken)(headers)).willReturn(scopes)
 
-      given(liveInfoService.authConnector.fetchNino()(headers)).willReturn(Some(nino))
-      given(liveInfoService.authConnector.fetchEnrolments()(headers)).willReturn(Some(enrolments))
-      given(liveInfoService.userInfoTransformer.transform(scopes, None, Some(nino), Some(enrolments))).willReturn(any[UserInfo], any[UserInfo])
+      given(liveInfoService.authConnector.fetchAuthority()(headers)).willReturn(Future(Option(authority)))
+      given(liveInfoService.userInfoTransformer.transform(scopes, None, Some(enrolments), Some(authority), Some(userDetails), Some(ggToken))).willReturn(any[UserInfo], any[UserInfo])
 
       await(liveInfoService.fetchUserInfo())
 
-      verify(liveInfoService.desConnector, never).fetchUserInfo(any[Option[Nino]])(any[HeaderCarrier])
-      verify(liveInfoService.authConnector).fetchNino()
-      verify(liveInfoService.authConnector).fetchEnrolments()
+      verify(liveInfoService.desConnector, never).fetchUserInfo(any[Authority])(any[HeaderCarrier])
+      verify(liveInfoService.authConnector).fetchEnrolments(authority)
     }
 
     "does not request AUTH::fetchNino nor DES::fetchUserInfo when the scopes does not contain 'address' nor 'profile' nor 'openid:gov-uk-identifiers'" in new Setup {
@@ -102,14 +116,14 @@ class UserInfoServiceSpec extends UnitSpec with MockitoSugar with ScalaFutures {
       val scopes = Set("openid:hmrc_enrolments")
       given(liveInfoService.thirdPartyDelegatedAuthorityConnector.fetchScopes(authBearerToken)(headers)).willReturn(scopes)
 
-      given(liveInfoService.authConnector.fetchEnrolments()(headers)).willReturn(Some(enrolments))
-      given(liveInfoService.userInfoTransformer.transform(scopes, None, None, Some(enrolments))).willReturn(any[UserInfo], any[UserInfo])
+      given(liveInfoService.authConnector.fetchAuthority()(headers)).willReturn(Option(authority))
+      given(liveInfoService.authConnector.fetchEnrolments(authority)(headers)).willReturn(Some(enrolments))
+      given(liveInfoService.userInfoTransformer.transform(scopes, None, Some(enrolments), Some(authority), None, None)).willReturn(any[UserInfo], any[UserInfo])
 
       await(liveInfoService.fetchUserInfo())
 
-      verify(liveInfoService.desConnector, never).fetchUserInfo(any[Option[Nino]])(any[HeaderCarrier])
-      verify(liveInfoService.authConnector, never).fetchNino()
-      verify(liveInfoService.authConnector).fetchEnrolments()
+      verify(liveInfoService.desConnector, never).fetchUserInfo(any[Authority])(any[HeaderCarrier])
+      verify(liveInfoService.authConnector).fetchEnrolments(authority)
     }
 
     "does not request AUTH::fetchEnrloments when the scopes does not contain 'openid:hmrc_enrolments'" in new Setup {
@@ -117,15 +131,14 @@ class UserInfoServiceSpec extends UnitSpec with MockitoSugar with ScalaFutures {
       val scopes = Set("address", "profile", "openid:gov-uk-identifiers")
       given(liveInfoService.thirdPartyDelegatedAuthorityConnector.fetchScopes(authBearerToken)(headers)).willReturn(scopes)
 
-      given(liveInfoService.authConnector.fetchNino()(headers)).willReturn(Some(nino))
-      given(liveInfoService.desConnector.fetchUserInfo(Some(nino))(headers)).willReturn(None)
-      given(liveInfoService.userInfoTransformer.transform(scopes, None, None, Some(enrolments))).willReturn(any[UserInfo], any[UserInfo])
+      given(liveInfoService.authConnector.fetchAuthority()(headers)).willReturn(Future(Option(authority)))
+      given(liveInfoService.desConnector.fetchUserInfo(authority)(headers)).willReturn(None)
+      given(liveInfoService.userInfoTransformer.transform(scopes, None, Some(enrolments), None, None, None)).willReturn(any[UserInfo], any[UserInfo])
 
       await(liveInfoService.fetchUserInfo())
 
-      verify(liveInfoService.authConnector, never).fetchEnrolments()
-      verify(liveInfoService.authConnector).fetchNino()
-      verify(liveInfoService.desConnector).fetchUserInfo(any[Option[Nino]])(any[HeaderCarrier])
+      verify(liveInfoService.authConnector, never).fetchEnrolments(any[Authority])(any[HeaderCarrier])
+      verify(liveInfoService.desConnector).fetchUserInfo(any[Authority])(any[HeaderCarrier])
     }
   }
 


### PR DESCRIPTION
New features:
- `email` - taken from `UserDetails`
- `government_gateway:
    { 
        "user_id": // GGW credId 
        "gateway_token": // GGW Token 
        "roles": // GGW Credential Role 
        "affinity_group": // Individual, Organisation, Agent
    }` - taken from `UserDetails`

Majority of the code refactoring is done:
- Use of flatmap to bind some `Futures` and their dependencies.
- Send less request per endpoint like `auth` as lot of information needs data from `auth` so it makes sense to ask it once.
- Use build in JSON Formatter provide by Play.
- Unify `api` a bit.
- Clean the code a little.